### PR TITLE
Block newsletter-containing popups from loading when coming from newsletter

### DIFF
--- a/wp-content/themes/rivard-report/functions.php
+++ b/wp-content/themes/rivard-report/functions.php
@@ -164,3 +164,21 @@ function rr_interstitial( $counter, $context ) {
 	}
 }
 add_action( 'largo_loop_after_post_x', 'rr_interstitial', 10, 2 );
+
+/**
+ * Enqueue Js to modify the behavior of Popmake
+ */
+function rivard_popmake_js() {
+	include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+	if ( is_plugin_active( 'popup-maker/popup-maker.php' ) ) {
+		wp_enqueue_script(
+			'rr-popmake',
+			get_stylesheet_directory_uri(). '/js/popmake.js',
+			array( 'jquery', 'popup-maker-site' ), // depends upon both of these
+			null,
+			true
+		);
+		error_log(var_export( 'much wow', true));
+	}
+}
+add_action( 'wp_enqueue_scripts', 'rivard_popmake_js' );

--- a/wp-content/themes/rivard-report/js/popmake.js
+++ b/wp-content/themes/rivard-report/js/popmake.js
@@ -1,0 +1,8 @@
+(function ($) {
+	$(document).on( 'pumBeforeOpen', function( ) {
+		var $popup = PUM.getPopup('#mc_embed_signup');
+		if (window.location.href.match(/utm_source=Rivard\+Report/i)) {
+			$popup.addClass('preventOpen');
+		}
+	});
+}(jQuery));


### PR DESCRIPTION
## changes

When Popmake is an active plugin:
- enqueue javascript that
- attaches a pre-display event handler to popmake plugins that
- if the popup contains a mailchimp form
- prevents the popup from being initialized

For https://github.com/INN/umbrella-rivard-report/issues/15