### PR TITLE
Fix for featured posts not having correct post classes

### DIFF
--- a/wp-content/themes/rivard-report/partials/rr-featured-image.php
+++ b/wp-content/themes/rivard-report/partials/rr-featured-image.php
@@ -7,7 +7,7 @@
 
 $thumbnail = get_the_post_thumbnail( $featured->ID, 'rect_thumb' );
 ?>
-	<div <?php post_class( 'rr-featured-image' ); ?>>
+	<div <?php post_class( 'rr-featured-image', $featured->ID ); ?>>
 		<div class="">
 			<div class="<?php echo join( ' ', $post_classes ); ?> ">
 

--- a/wp-content/themes/rivard-report/partials/rr-featured-top.php
+++ b/wp-content/themes/rivard-report/partials/rr-featured-top.php
@@ -8,7 +8,7 @@
 $thumbnail = get_the_post_thumbnail( $bigStoryPost->ID, 'rect_thumb' );
 $excerpt = largo_excerpt( $bigStoryPost, 1, false, '', false );
 
-	echo '<div '; post_class( 'rr-featured-top' ); echo '>';
+	echo '<div '; post_class( 'rr-featured-top', $bigStoryPost->ID ); echo '>';
 		if ( ! empty( $thumbnail ) ) {
 			?>
 				<h5 class="top-tag"><?php largo_top_term( array( 'post' => $bigStoryPost->ID ) ); ?></h5>


### PR DESCRIPTION
Adds the post ID to `post_class()` calls for featured images and for the home top story


Because the wrong post classes were being output.

For HelpScout ticket 1389.