### PR TITLE
Helpscout 2214: Remove INN/Largo GA bits

### DIFF
--- a/wp-content/themes/rivard-report/functions.php
+++ b/wp-content/themes/rivard-report/functions.php
@@ -64,14 +64,15 @@ function largo_child_require_files() {
 		'/inc/enqueue.php',
 	);
 
-
 	if ( class_exists( 'WP_CLI_Command' ) ) {
 		require __DIR__ . '/inc/cli.php';
 		WP_CLI::add_command( 'rr', 'RR_WP_CLI' );
 	}
 
 	foreach ($includes as $include ) {
-		require_once( get_stylesheet_directory() . $include );
+		if ( 0 === validate_file( get_stylesheet_directory() . $include ) ) {
+			require_once( get_stylesheet_directory() . $include );
+		}
 	}
 }
 add_action( 'after_setup_theme', 'largo_child_require_files' );

--- a/wp-content/themes/rivard-report/functions.php
+++ b/wp-content/themes/rivard-report/functions.php
@@ -60,7 +60,8 @@ function largo_child_require_files() {
 	$includes = array(
 		'/homepages/layouts/RivardReportHomepage.php',
 		'/inc/post-tags.php',
-		'/inc/taxonomies.php'
+		'/inc/taxonomies.php',
+		'/inc/enqueue.php',
 	);
 
 

--- a/wp-content/themes/rivard-report/inc/enqueue.php
+++ b/wp-content/themes/rivard-report/inc/enqueue.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * remove Largo's google analytics integration, as they're managing their tags themselves
+ *
+ * @since Largo 0.5.5.4
+ * @since Helpscout ticket https://secure.helpscout.net/conversation/615103723/2214/?folderId=1219602
+ * @since 2018-07-16
+ */
+function rr_remove_largo_google_analytics() {
+	remove_action( 'wp_head', 'largo_google_analytics' );
+}
+add_action( 'wp_head', 'rr_remove_largo_google_analytics', 1 );


### PR DESCRIPTION
## Changes

- remove_action's the Largo function that emits the Google Analytics functions in Largo if the `ga_id` is set.

## Why

For [Helpscout 2214](https://secure.helpscout.net/conversation/615103723/2214/?folderId=1219602), where they objected to the GA functions that ping INN and Largo's GA IDs. 

Related: https://github.com/INN/largo/issues/1495