### PR TITLE
Remove "Homepage hidden" prominence posts from homepage queries

### DIFF
--- a/wp-content/themes/rivard-report/homepages/layouts/RivardReportHomepage.php
+++ b/wp-content/themes/rivard-report/homepages/layouts/RivardReportHomepage.php
@@ -294,6 +294,14 @@ function rr_homepage_hidden_pre_get_posts( $query ) {
 		return;
 	}
 
+	if (
+		( is_string( $query->query_vars['post_type'] ) && 'post' !== $query->query_vars['post_type'] )
+		||
+		( is_array( $query->query_vars['post_type'] ) && ! in_array( 'post', $query->query_vars['post_type'], true ) )
+	) {
+		return;
+	}
+
 	if ( is_array( $query->query_vars ) ) {
 		// here we modify the tax query.
 		$query->query_vars['tax_query'][] = array(


### PR DESCRIPTION
## Changes

- adds a filter on WP_Query using `pre_get_posts` action to add a term to the `tax_query` to exclude posts that have the "homepage-hidden" prominence term.

## Why

For https://secure.helpscout.net/conversation/682348677/2630?folderId=1219602 and #35

> Checking a box on the post's edit screen prevents the post from showing up on the homepage.
